### PR TITLE
nova v6.1.1 for the switch-kilo patched version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "openstack-nova",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "Puppet Labs and OpenStack Contributors",
   "summary": "Puppet module for OpenStack Nova",
   "license": "Apache-2.0",


### PR DESCRIPTION
The version need to be different than the "official" openstack-nova from puppet forge.
